### PR TITLE
Improve rendering inside webview

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {WebView} from 'react-native';
+import {View,WebView} from 'react-native';
 import defineWebViewMethods from './defineWebViewMethods';
 import defineWebViewProperties from './defineWebViewProperties';
 import CanvasRenderingContext2D from './CanvasRenderingContext2D';
@@ -79,13 +79,15 @@ export default class Canvas extends Component {
   render() {
     const {width, height} = this;
     return (
-      <WebView
-        ref={this.handleRef}
-        style={{width, height, flexGrow: 1, flexShrink: 1}}
-        source={require('./index.html')}
-        onMessage={this.handleMessage}
-        onLoad={this.handleLoad}
-      />
+      <View style={{width, height, overflow: 'hidden'}}>
+        <WebView
+          ref={this.handleRef}
+          style={{width, height, backgroundColor: 'transparent'}}
+          source={require('./index.html')}
+          onMessage={this.handleMessage}
+          onLoad={this.handleLoad}
+        />
+      </View>
     );
   }
 }

--- a/src/defineWebViewProperties.js
+++ b/src/defineWebViewProperties.js
@@ -19,6 +19,11 @@ const defineWebViewProperties = (targetName, properties) => target => {
               value,
             },
           });
+
+          if (this.forceUpdate) {
+              this.forceUpdate()
+          }
+
           return (this[privateKey] = value);
         },
       };

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <html>
-  <body>
+  <body style="margin: 0; padding: 0;">
     <script src="./webview.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This introduces a few quality-of-life changes to the library:

1. The default body padding and margin is removed from the embedded webview document (so that the rendered canvas starts at the top right corner.
2. The webview is wrapped in an exactly-sized view, so that overflow is hidden.
3. Changes to the canvas properties (width, height) cause the webview to be re-rendered, so that these properties now rightly affect the underlying canvas.

I suggest you try these changes alongside https://github.com/iddan/react-native-canvas/pull/10 :-)