### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "eslint-config-fbjs-opensource": "^1.0.0",
     "prettier": "^1.5.3"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "repository": "https://github.com/iddan/react-native-canvas"
 }


### PR DESCRIPTION
Just makes it easier to navigate from the [npm package page](https://www.npmjs.com/package/react-native-canvas) to the github repository.