### PR TITLE
WIP: Move default width and height to Canvas component

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -3,6 +3,29 @@ import {Image, ScrollView, StatusBar, Text, View, StyleSheet} from 'react-native
 
 import Canvas, {Image as CanvasImage, Path2D} from 'react-native-canvas';
 
+const MyCanvas = ({onRender, style = {}, ...rest}) => {
+  const width = style.width || 300;
+  const height = style.height || 150;
+  return (
+    <Canvas ref={onRender} {...{style: {...style, width, height}, ...rest}} />
+  );
+};
+
+const handleCanvas = (canvas) => {
+  const ctx = canvas.getContext('2d');
+  const ratio = 2;
+  ctx.width = canvas.width;
+  ctx.height = canvas.height;
+
+  ctx.width *= ratio;
+  ctx.height *= ratio;
+
+  ctx.fillStyle = 'purple';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.scale(ratio, ratio);
+  console.log('handleCanvas', canvas.width, canvas.height, ctx.width, ctx.height);
+};
+
 class App extends Component {
   async handlePurpleRect(canvas) {
     canvas.width = 100;
@@ -226,6 +249,9 @@ class App extends Component {
             <View style={styles.exampleRight}>
               <Image source={require('./images/panorama.png')} style={{width: 100, height: 100}} />
             </View>
+          </View>
+          <View style={styles.example}>
+            <MyCanvas onRender={handleCanvas} {...{style: {width: 320, height: 200}}}/>
           </View>
         </ScrollView>
       </View>

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -1182,7 +1182,7 @@ csurf@~1.8.3:
     csrf "~3.0.0"
     http-errors "~1.3.1"
 
-"ctx-polyfill@github:lifaon74/ctx-polyfill":
+ctx-polyfill@lifaon74/ctx-polyfill:
   version "1.1.4"
   resolved "https://codeload.github.com/lifaon74/ctx-polyfill/tar.gz/f39f2d22be29dc87f211e1c363edb324bee173b4"
 

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -36,10 +36,8 @@ export default class Canvas extends Component {
   listeners = [];
   context2D = new CanvasRenderingContext2D(this);
 
-  constructor({width = 300, height = 150}) {
+  constructor() {
     super();
-    this.width = width;
-    this.height = height;
     this.bus.pause();
   }
 

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -36,8 +36,12 @@ export default class Canvas extends Component {
   listeners = [];
   context2D = new CanvasRenderingContext2D(this);
 
-  constructor() {
-    super();
+  constructor(props = {}) {
+    super(props);
+    const {style = {}} = props;
+    const {width, height} = style;
+    this.width = width;
+    this.height = height;
     this.bus.pause();
   }
 
@@ -108,10 +112,10 @@ export default class Canvas extends Component {
     const {style} = this.props;
     if (Platform.OS === 'android') {
       return (
-        <View style={{width, height, overflow: 'hidden', flex: 0, ...style}}>
+        <View style={{...style, width, height}}>
           <WebView
             ref={this.handleRef}
-            style={{width, height, overflow: 'hidden', backgroundColor: 'transparent'}}
+            style={{width, height, backgroundColor: 'transparent'}}
             source={{html}}
             onMessage={this.handleMessage}
             onLoad={this.handleLoad}
@@ -125,10 +129,10 @@ export default class Canvas extends Component {
       );
     }
     return (
-      <View style={{width, height, overflow: 'hidden', flex: 0, ...style}}>
+      <View style={{ ...style, width, height}}>
         <WebView
           ref={this.handleRef}
-          style={{width, height, overflow: 'hidden', backgroundColor: 'transparent'}}
+          style={{width, height, backgroundColor: 'transparent'}}
           source={{html, baseUrl: '/'}}
           onMessage={this.handleMessage}
           onLoad={this.handleLoad}

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -10,7 +10,7 @@ export {default as Path2D} from './Path2D';
 import './CanvasGradient';
 
 @webviewTarget('canvas')
-@webviewProperties({width: 300, height: 150})
+@webviewProperties()
 @webviewMethods(['toDataURL'])
 export default class Canvas extends Component {
   static propTypes = {
@@ -36,8 +36,10 @@ export default class Canvas extends Component {
   listeners = [];
   context2D = new CanvasRenderingContext2D(this);
 
-  constructor() {
+  constructor({width = 300, height = 150}) {
     super();
+    this.width = width;
+    this.height = height;
     this.bus.pause();
   }
 

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -10,7 +10,7 @@ export {default as Path2D} from './Path2D';
 import './CanvasGradient';
 
 @webviewTarget('canvas')
-@webviewProperties()
+@webviewProperties({})
 @webviewMethods(['toDataURL'])
 export default class Canvas extends Component {
   static propTypes = {

--- a/src/index.html
+++ b/src/index.html
@@ -2,9 +2,12 @@
   <head>
     <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scaleable=no' name='viewport'>
     <style>
-      body {
+      html, body, canvas {
         margin: 0;
         padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
       }
     </style>
   </head>


### PR DESCRIPTION
**Problem**:
With `webviewProperties` decorator always have passed default values to the canvas wrapper (`View`), which is not equal of canvas size.

```javascript
const handleCanvas = (canvas) => {
    const ctx = canvas.getContext('2d');
    ctx.fillStyle = 'purple';
    console.log(canvas.width, canvas.height)
    ctx.fillRect(0, 0, canvas.width, canvas.height);
};
...
<Canvas ref={handleCanvas} {...{width: 300, height: 400, style: {width: 300, height: 400}}}/>
```

![](https://imgur.com/UMVSDFy.png)

**Solution**:
Moved default size values (300x150) to constructor
Possible solution for https://github.com/iddan/react-native-canvas/issues/48

**Result**:
```
<Canvas ref={handleCanvas} {...{width: 400, height: 200, style: {width: 400, height: 200}}}/>
```
![](https://imgur.com/grf6Hyg.png)