### PR TITLE
Update package.json due to dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prettier": "^1.14.2"
   },
   "dependencies": {
-    "ctx-polyfill": "lifaon74/ctx-polyfill"
+    "ctx-polyfill": "1.1.4"
   },
   "repository": "https://github.com/iddan/react-native-canvas"
 }


### PR DESCRIPTION
Hello. I would like to use this library via npm for an enterprise project of mine but your dependency "ctx-polyfill" is causing issues. That branch it is referencing is no longer there. The owners of that repo must have cleaned it up. I looked up what the current version of ctx-polyfill is on npm. I hope we can get this merged/fixed soon because this looks like an excellent tool and I would love to use it.