### PR TITLE
add windows compability

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-canvas",
   "license": "MIT",
   "version": "0.1.30",
-  "main": "dist/Canvas.js",
+  "main": "dist/Canvas",
   "scripts": {
     "build": "babel src --out-dir dist --copy-files --compact false && node bundle-html.js ./dist/index.html",
     "copy-to-example": "rsync -rv dist example/node_modules/react-native-canvas",
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "ctx-polyfill": "^1.1.4",
-    "react-native-webview": "^5.2.0"
+    "react-native-webview": "^5.4.0"
   },
   "repository": "https://github.com/iddan/react-native-canvas"
 }

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,10 @@
   <head>
     <meta content='width=device-width, initial-scale=1, maximum-scale=1, user-scaleable=no' name='viewport'>
     <style>
+      html {
+        -ms-content-zooming: none;
+        -ms-touch-action: pan-x pan-y;
+      }
       body {
         position: fixed;
         top: 0;


### PR DESCRIPTION
`react-native-webview` is not compatible with `react-native-windows` and second, IE (WebView engine) does not react to `user-scaleable=no`.

This PR duplicates the Canvas.js (maybe better to move the import and export of `WebView` to a separate file?) and adds IE specific properties to remove the pinch-to-zoom ability on windows.