### PR TITLE
make react-native-webview a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "prettier": "^1.14.2"
   },
   "dependencies": {
-    "ctx-polyfill": "^1.1.4",
-    "react-native-webview": "^5.4.0"
+    "ctx-polyfill": "^1.1.4"
+  },
+  "peerDependencies": {
+    "react-native-webview": ">=5.0.1"
   },
   "repository": "https://github.com/iddan/react-native-canvas"
 }


### PR DESCRIPTION
It would be better to add react-native-webview as a peer dependency so that client could upgrade its version directly. Otherwise, if the client have a different version react-native-webview installed and linked, the 2 different react-native-webview js versions (client installed one and react-native-canvas embed one)  - given one of them doesn't match its linked native code version - might cause issues.

* Some more details about peer dependency: https://stackoverflow.com/questions/26737819/why-use-peer-dependencies-in-npm-for-plugins
* The reason that react-native-webview needs to >=5.0.1:
https://github.com/react-native-community/react-native-webview/releases?after=v5.0.2