### PR TITLE
WebView flattenObject() skip DOM Nodes and recursive for nest object

### DIFF
--- a/src/webview.js
+++ b/src/webview.js
@@ -5,16 +5,27 @@ const ID = () =>
     .toString(32)
     .slice(2);
 
+const flattenObjectCopyValue = (flatObj, srcObj, key) => {
+  const value = srcObj[key];
+  if (typeof value === 'function') {
+    return;
+  }
+  if (typeof value === 'object' && value instanceof Node) {
+    return;
+  }
+  flatObj[key] = flattenObject(value);
+}
+
 const flattenObject = object => {
-  if (typeof object !== 'object') {
+  if (typeof object !== 'object' || object === null) {
     return object;
   }
   const flatObject = {};
   for (const key in object) {
-    flatObject[key] = object[key];
+    flattenObjectCopyValue(flatObject, object, key);
   }
   for (const key in Object.getOwnPropertyNames(object)) {
-    flatObject[key] = object[key];
+    flattenObjectCopyValue(flatObject, object, key);
   }
   return flatObject;
 };


### PR DESCRIPTION
We found there is an issue when trying to load image on some old Android device (e.g. WebView version 37.0.0.0/Android 5.0.2).
The reason is:
- WebView side will try to send image 'load' event back to RN;
- image event has a parameter `target: flattenObject(img)`;
- there is a `ownerDocument` on DOM Node objects, which would cause `Converting circular structure to JSON` error when trying to call `JSON.stringify()` on it.

So I am trying to fix this issue by:
- skip function and DOM properties in `flattenObject()`, since they seems useless to send to RN side;
- recursive flatten object properties, since there might be nest structure inside plain objects that contains DOM properties.