### PR TITLE
Update example to fix potential error with StyleSheet when used in Typescript.

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import {Image, ScrollView, StatusBar, Text, View, StyleSheet} from 'react-native';
+import {Image, ScrollView, StatusBar, View, StyleSheet} from 'react-native';
 
 import Canvas, {Image as CanvasImage, Path2D, ImageData} from 'react-native-canvas';
 
@@ -162,28 +162,29 @@ export default class App extends Component {
   }
 }
 
-const full = {
-  position: 'absolute',
-  top: 0,
-  left: 0,
-  width: '100%',
-  height: '100%',
-};
-
-const cell = {
-  flex: 1,
-  padding: 10,
-  justifyContent: 'center',
-  alignItems: 'center',
-};
+const commonStyles = StyleSheet.create({
+  full: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+  },
+  cell: {
+    flex: 1,
+    padding: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
 
 const styles = StyleSheet.create({
   container: {
     backgroundColor: 'white',
-    ...full,
+    ...commonStyles.full,
   },
   examples: {
-    ...full,
+    ...commonStyles.full,
     padding: 5,
     paddingBottom: 0,
   },
@@ -193,9 +194,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
   },
   exampleLeft: {
-    ...cell,
+    ...commonStyles.cell,
   },
   exampleRight: {
-    ...cell,
+    ...commonStyles.cell,
   },
 });

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import {View, Platform, ViewStylePropTypes, StyleSheet} from 'react-native';
+import {View, Platform, ViewPropTypes, StyleSheet} from 'react-native';
 import {WebView} from 'react-native-webview';
 import Bus from './Bus';
 import {webviewTarget, webviewProperties, webviewMethods, constructors, WEBVIEW_TARGET} from './webview-binders';
@@ -25,7 +25,7 @@ const stylesheet = StyleSheet.create({
 @webviewMethods(['toDataURL'])
 export default class Canvas extends Component {
   static propTypes = {
-    style: PropTypes.shape(ViewStylePropTypes),
+    style: ViewPropTypes.style,
     baseUrl: PropTypes.string,
     originWhitelist: PropTypes.arrayOf(PropTypes.string),
   };


### PR DESCRIPTION
When following the example code usage in Typescript, there will be an error with `StyleSheet` usage when using spread operator with the two constants `full` and `cell` . The two shall be declared in a `StyleSheet.create()` function for type safety.

This pull request fixes the aforementioned potential error for a better example.