### PR TITLE
fix: white flashing on iOS by zeroing opacity while loading

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -150,7 +150,7 @@ export default class Canvas extends Component {
       );
     }
     return (
-      <View style={[stylesheet.container, {width, height}, style]}>
+      <View style={[stylesheet.container, {width, height, opacity: this.loaded ? 1 : 0}, style]}>
         <WebView
           ref={this.handleRef}
           style={[stylesheet.webview, {height, width}]}


### PR DESCRIPTION
Since some time (I think it was when I updated an app to react-native 0.60) there was a random, white flash before the canvas was rendered/shown. On lower end devices (iPhone 5) it was pretty long, but on higher ones (like 7) it was shorter. 

I figured out that this due to loading the html file, so I made the <View /> invisible while loading.

Let me know if this does not feel like a good solution.