### PR TITLE
Remove propTypes in Canvas.js

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
-import {View, Platform, ViewPropTypes, StyleSheet} from 'react-native';
+import {View, Platform, StyleSheet} from 'react-native';
 import {WebView} from 'react-native-webview';
 import Bus from './Bus';
 import {webviewTarget, webviewProperties, webviewMethods, constructors, WEBVIEW_TARGET} from './webview-binders';
@@ -34,12 +33,6 @@ export default class Canvas extends Component {
   state = {
     isLoaded: false,
   }
-
-  static propTypes = {
-    style: ViewPropTypes.style,
-    baseUrl: PropTypes.string,
-    originWhitelist: PropTypes.arrayOf(PropTypes.string),
-  };
 
   addMessageListener = listener => {
     this.listeners.push(listener);


### PR DESCRIPTION
Fixes iddan/react-native-canvas#196 

In line with https://github.com/facebook/react-native/issues/21342

This was broken for `react-native-web` in version [0.12.0](https://github.com/necolas/react-native-web/releases/tag/0.12.0)

This way `react-native-canvas` does not give a type error when imported in a `web` environment.