### PR TITLE
Disable overScroll for Android

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -144,6 +144,7 @@ export default class Canvas extends Component {
             originWhitelist={originWhitelist}
             onMessage={this.handleMessage}
             onLoad={this.handleLoad}
+            overScrollMode="never"
             mixedContentMode="always"
             scalesPageToFit={false}
             javaScriptEnabled


### PR DESCRIPTION
The overScroll stretch effect on Android 12+ will affect the Canvas when it is used to implement touch drawing.