### PR TITLE
Fix CanvasRenderingContext2D.js - Add missing ellipse method

### DIFF
--- a/src/CanvasRenderingContext2D.js
+++ b/src/CanvasRenderingContext2D.js
@@ -35,6 +35,7 @@ import {webviewTarget, webviewProperties, webviewMethods} from './webview-binder
   'drawImage',
   'drawWidgetAsOnScreen',
   'drawWindow',
+  'ellipse',
   'fill',
   'fillRect',
   'fillText',


### PR DESCRIPTION
The ellipse method was missing, so it was unusable.